### PR TITLE
fix: atomic Firestore writes, highlight bug, logout cleanup, lint config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,10 @@ pnpm start          # Dev server (ng serve)
 pnpm build          # Production build → www/
 pnpm run build:prod # Ionic prod build with service worker (outputs to www/browser)
 pnpm test           # Karma unit tests
-pnpm lint           # ESLint
+pnpm lint           # ESLint (flat config: eslint.config.mjs)
 ```
+
+Lint uses ESLint 10 flat config (`eslint.config.mjs`) via the `@angular-eslint/builder:lint` builder. `src/assets/**` (static reading content) is excluded. Project-specific rule choices: `prefer-standalone` and `prefer-inject` are **off** (the app intentionally uses NgModules + constructor DI), and `no-explicit-any` is a **warning** (tracked Known Issue), so `pnpm lint` exits 0 with warnings.
 
 Run a single test file by passing `--include` to karma or by modifying the test entry temporarily. There is no shorthand script for this.
 
@@ -67,7 +69,8 @@ Rules live in `firestore.rules`: a user may read/write `/users/{userId}` only wh
 ## Conventions & Gotchas
 
 - **Calendar date base year.** Reading days are stored as `MM-dd` strings (no year). To do date math/formatting, the code prefixes a fixed year: `TodayPage` and `NotesPage` use `"2015-"`, while `MonthPage` uses the **current** year for the calendar's read-marks. Keep stored keys and calendar keys aligned. ⚠️ 2015 is not a leap year, so any `DateTime.fromFormat("2015-02-29", …)` is invalid — use a leap year base (e.g. 2016) if touching this.
-- **`html` vs raw content in TodayPage.** `this.html` holds the rendered content and is also where highlight `<span>`s get injected. Do not re-run `highlightedHtml` against an already-highlighted string — keep the raw content separate from the highlighted output (see Known Issues #2).
+- **`html` vs raw content in TodayPage.** `this.rawHtml` holds the pristine reading content; `this.html` is the rendered copy with highlight `<span>`s injected. Always derive `html` from `rawHtml` (never re-highlight `html` in place) so spans don't nest on `valueChanges` re-emission.
+- **Firestore writes use atomic field ops.** `ReadingDbService` writes with `set({field: arrayUnion/arrayRemove(...)}, {merge: true})` — never a read-then-write of the whole document. This means a user doc may legitimately contain only *some* of `days`/`favorites`/`notes`, so guard array reads with `?? []`. (The compat `set` typings require the full `Item`, hence the `as unknown as Item` casts around `FieldValue`.)
 - **Firebase SDK is mixed.** Auth uses the modern modular API (`provideAuth`/`getAuth`, `@angular/fire/auth`); Firestore and Analytics use the **deprecated** `@angular/fire/compat` API (`AngularFirestore`, `AngularFireAnalytics`). New code should prefer the modular API.
 - **`userDocValue()` re-emits.** It returns Firestore `valueChanges()`, which fires on every document change. Subscribers in `TodayPage`/`MonthPage`/`NotesPage` re-run their full callback each emission — make those callbacks idempotent.
 - **No unit tests.** There are currently zero `*.spec.ts` files despite `pnpm test` (Karma) being wired up.
@@ -75,7 +78,12 @@ Rules live in `firestore.rules`: a user may read/write `/users/{userId}` only wh
 
 ## Known Issues (candidates for improvement)
 
-1. **Read-modify-write races in `ReadingDbService`.** Every mutation does `.get()` → mutate whole `Item` → `.update(data)`, so concurrent writes (multiple tabs/devices) clobber each other and the whole doc is rewritten each time. Prefer atomic `arrayUnion`/`arrayRemove` for `days`/`favorites`, and a transaction for `notes`.
-2. **Highlight double-wrapping.** `TodayPage.refreshView` reassigns `this.html = highlightedHtml(this.html, notes)` inside the `valueChanges` subscription, so repeated emissions re-highlight already-highlighted HTML and nest spans. Derive `html` from an untouched raw string instead.
-3. **No logout cleanup.** `ReadingDbService` listens for `EVENT_USER_LOGIN` but nothing resets `userDoc` on sign-out, leaving it pointed at the previous user. Add an explicit logout event/handler.
-4. **Pervasive `any`.** `MaterialService.data`, `AuthService.user`, and the `content` ViewChilds are untyped. Typing `index.json` (a `ReadingDay`/month map) and storing only the email (not the whole Firebase user object) in `localStorage` would harden things.
+Remaining:
+1. **Leap-year date base.** TodayPage/NotesPage build dates with a `"2015-"` prefix; 2015 isn't a leap year, so Feb 29 (`02-29`) navigation/formatting is invalid. Switch the base to a leap year (e.g. 2016).
+2. **Pervasive `any`.** `MaterialService.data`, `AuthService.user`, and the `content` ViewChilds are untyped. Typing `index.json` (a `ReadingDay`/month map) and storing only the email (not the whole Firebase user object) in `localStorage` would harden things.
+3. **Mixed Firebase SDK.** Firestore/Analytics still use the deprecated `@angular/fire/compat` API; migrating to the modular API (as auth already uses) would let the `as unknown as Item` casts in `ReadingDbService` go away.
+
+Fixed (2026-06-04):
+- ~~Read-modify-write races in `ReadingDbService`~~ — now uses atomic `arrayUnion`/`arrayRemove` with `set(..., {merge: true})`.
+- ~~Highlight double-wrapping in TodayPage~~ — `html` is now always derived from `rawHtml`.
+- ~~No logout cleanup~~ — `EVENT_USER_LOGOUT` is now published by `AuthService` and resets `userDoc`.

--- a/angular.json
+++ b/angular.json
@@ -127,14 +127,11 @@
           }
         },
         "lint": {
-          "builder": "@angular-devkit/build-angular:tslint",
+          "builder": "@angular-eslint/builder:lint",
           "options": {
-            "tsConfig": [
-              "src/tsconfig.app.json",
-              "src/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html"
             ]
           }
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,52 @@
+// @ts-check
+// Flat ESLint config (ESLint 10 + angular-eslint 21).
+// Uses the individual angular-eslint / typescript-eslint plugins directly,
+// since the `angular-eslint` / `typescript-eslint` meta-packages are not installed.
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import angular from '@angular-eslint/eslint-plugin';
+import angularTemplate from '@angular-eslint/eslint-plugin-template';
+import templateParser from '@angular-eslint/template-parser';
+
+export default [
+  {
+    // src/assets holds the static Harvard Classics reading content (raw HTML,
+    // not Angular templates) — never lint it.
+    ignores: ['www/**', 'coverage/**', 'node_modules/**', '.angular/**', 'src/assets/**'],
+  },
+  // TypeScript source files.
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: 'module',
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      '@angular-eslint': angular,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      ...angular.configs.recommended.rules,
+      // This app is intentionally NgModule-based with constructor DI (see CLAUDE.md);
+      // these v21 defaults push the opposite architecture, so they're disabled here.
+      '@angular-eslint/prefer-standalone': 'off',
+      '@angular-eslint/prefer-inject': 'off',
+      // `any` is pervasive and tracked as a Known Issue — surface it without blocking lint.
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+  // Angular HTML templates.
+  {
+    files: ['**/*.html'],
+    languageOptions: {
+      parser: templateParser,
+    },
+    plugins: {
+      '@angular-eslint/template': angularTemplate,
+    },
+    rules: {
+      ...angularTemplate.configs.recommended.rules,
+    },
+  },
+];

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -4,12 +4,11 @@ import {
     createUserWithEmailAndPassword,
     GoogleAuthProvider,
     onAuthStateChanged,
-    sendPasswordResetEmail,
     signInWithEmailAndPassword,
     signInWithPopup,
     signOut,
 } from '@angular/fire/auth';
-import {EVENT_USER_LOGIN} from '../constants';
+import {EVENT_USER_LOGIN, EVENT_USER_LOGOUT} from '../constants';
 import {Events} from "../services/events.service";
 
 @Injectable({
@@ -32,6 +31,7 @@ export class AuthService implements OnDestroy {
                 this.events.publish(EVENT_USER_LOGIN, user);
             } else {
                 localStorage.removeItem('user');
+                this.events.publish(EVENT_USER_LOGOUT);
             }
         });
     }

--- a/src/app/auth/login/login.page.ts
+++ b/src/app/auth/login/login.page.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component} from '@angular/core';
 import {Router} from '@angular/router';
 import {AuthService} from '../auth.service';
 
@@ -8,13 +8,11 @@ import {AuthService} from '../auth.service';
     styleUrls: ['./login.page.scss'],
     standalone: false
 })
-export class LoginPage implements OnInit {
+export class LoginPage {
     userEmail!: string;
     userPassword!: string;
 
     constructor(public authService: AuthService, private router: Router) {}
-
-    ngOnInit() {}
 
     async emailLogin() {
         await this.authService.emailLogin(this.userEmail, this.userPassword);

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -1,2 +1,3 @@
 export const EVENT_FINISHED_READING = 'event:finished-reading';
 export const EVENT_USER_LOGIN = 'event:login';
+export const EVENT_USER_LOGOUT = 'event:logout';

--- a/src/app/month/month.page.ts
+++ b/src/app/month/month.page.ts
@@ -65,7 +65,7 @@ export class MonthPage implements OnInit, OnDestroy {
     this.dbSub = this.readDb.userDocValue().subscribe((data) => {
       const year = DateTime.now().year;
       this.dateMulti = [];
-      if (data) data.days.forEach((x) => this.dateMulti.push(year + "-" + x));
+      if (data) (data.days ?? []).forEach((x) => this.dateMulti.push(year + "-" + x));
     });
     this.material.ready().then((json) => {
       this.data = json[this.month];

--- a/src/app/notes/notes.page.ts
+++ b/src/app/notes/notes.page.ts
@@ -19,7 +19,7 @@ export class NotesPage implements OnInit, OnDestroy {
     this.dbSub = this.db.userDocValue().subscribe(data => {
       if (!data) return;
       this.notes = {};
-      data.notes.forEach(note => {
+      (data.notes ?? []).forEach(note => {
         const key = '2015-' + note.day;
         this.notes[key] = this.notes[key] || [];
         this.notes[key].push({ day: note.day, text: note.text });

--- a/src/app/services/readingdb.service.ts
+++ b/src/app/services/readingdb.service.ts
@@ -1,6 +1,9 @@
 import {Injectable, OnDestroy} from '@angular/core';
-import {EVENT_FINISHED_READING, EVENT_USER_LOGIN} from '../constants';
+import {EVENT_FINISHED_READING, EVENT_USER_LOGIN, EVENT_USER_LOGOUT} from '../constants';
 import {AngularFirestore, AngularFirestoreDocument} from '@angular/fire/compat/firestore';
+import firebase from 'firebase/compat/app';
+// Side-effect import: attaches the `firestore` namespace (incl. FieldValue) onto `firebase`.
+import 'firebase/compat/firestore';
 
 import {EMPTY} from 'rxjs';
 import {Events} from "./events.service";
@@ -17,17 +20,15 @@ export interface Item {
     notes: Note[];
 }
 
+const arrayUnion = (...elements: unknown[]) => firebase.firestore.FieldValue.arrayUnion(...elements);
+const arrayRemove = (...elements: unknown[]) => firebase.firestore.FieldValue.arrayRemove(...elements);
+
 @Injectable({
     providedIn: 'root'
 })
 export class ReadingDbService implements OnDestroy {
     private userDoc: AngularFirestoreDocument<Item> | null = null;
     private markDayAsReadHandler = (day: string) => this.markDayAsRead(day);
-    private INITIAL_DATA = {
-        days: [],
-        favorites: [],
-        notes: []
-    };
 
     constructor(private auth: AuthService,
                 private events: Events,
@@ -37,7 +38,10 @@ export class ReadingDbService implements OnDestroy {
         }
         events.subscribe(EVENT_FINISHED_READING, this.markDayAsReadHandler);
         events.subscribe(EVENT_USER_LOGIN, (user: any) => {
-            this.userDoc = afs.doc<Item>(`/users/${user.email}`);
+            this.userDoc = user?.email ? afs.doc<Item>(`/users/${user.email}`) : null;
+        });
+        events.subscribe(EVENT_USER_LOGOUT, () => {
+            this.userDoc = null;
         });
     }
 
@@ -46,95 +50,52 @@ export class ReadingDbService implements OnDestroy {
     }
 
     public highlightText(day: string, text: string): void {
-        if (this.auth.userEmail === null) {
+        if (!this.userDoc) {
             return;
         }
-        this.userDoc!.get().subscribe((val) => {
-            if (val.exists) {
-                const data = val.data();
-                if (!data) return;
-                data.notes.push({day: day, text: text});
-                this.userDoc!.update(data).then().catch(err => console.error('Error saving note:', err));
-            } else {
-                const data = { ...this.INITIAL_DATA, notes: [{day: day, text: text}] };
-                this.userDoc!.set(data).then().catch(err => console.error('Error creating document:', err));
-            }
-        });
+        // arrayUnion + merge creates the doc if absent and is atomic w.r.t. concurrent writes.
+        this.userDoc.set({notes: arrayUnion({day, text})} as unknown as Item, {merge: true})
+            .catch(err => console.error('Error saving note:', err));
     }
 
     public removeHighlightedText(day: string, text: string): void {
-        if (this.auth.userEmail === null) {
+        if (!this.userDoc) {
             return;
         }
-        this.userDoc!.get().subscribe((val) => {
-            if (!val.exists) {
-                return;
-            }
-            const data = val.data();
-            if (!data) return;
-            const idx = this.searchNoteInNotes(data.notes, day, text);
-            if (idx !== -1) {
-                data.notes.splice(idx, 1);
-                this.userDoc!.update(data).then().catch(err => console.error('Error removing note:', err));
-            }
-        });
+        // arrayRemove matches array elements by deep equality, so {day, text} removes the exact note.
+        this.userDoc.set({notes: arrayRemove({day, text})} as unknown as Item, {merge: true})
+            .catch(err => console.error('Error removing note:', err));
     }
 
     userDocValue() {
-        if (this.auth.userEmail === null) {
+        if (!this.userDoc) {
             console.log('User not logged in, not returning days read');
             return EMPTY;
         }
-        return this.userDoc?.valueChanges() ?? EMPTY;
+        return this.userDoc.valueChanges();
     }
 
     toggleFavorite(day: string) {
-        if (this.auth.userEmail === null) {
+        if (!this.userDoc) {
             return;
         }
-        this.userDoc!.get().subscribe((val) => {
-            if (val.exists) {
-                const data = val.data();
-                if (!data) return;
-                const dayIndex = data.favorites.indexOf(day);
-                if (dayIndex === -1) {
-                    data.favorites.push(day);
-                } else {
-                    data.favorites.splice(dayIndex, 1);
-                }
-                this.userDoc!.update(data).then().catch(err => console.error('Error updating favorites:', err));
-            } else {
-                const data = { ...this.INITIAL_DATA, favorites: [day] };
-                this.userDoc!.set(data).then().catch(err => console.error('Error creating document:', err));
-            }
+        const doc = this.userDoc;
+        // Read only to decide direction; the write itself is an atomic field op, so it
+        // never clobbers concurrent changes to days/notes.
+        doc.get().subscribe((snap) => {
+            const isFavorite = (snap.data()?.favorites ?? []).indexOf(day) !== -1;
+            const change = isFavorite ? arrayRemove(day) : arrayUnion(day);
+            doc.set({favorites: change} as unknown as Item, {merge: true})
+                .catch(err => console.error('Error updating favorites:', err));
         });
-    }
-
-    private searchNoteInNotes(notes: Note[], day: string, text: string): number {
-        for (let i = 0; i < notes.length; i++) {
-            const item = notes[i];
-            if (item.day === day && item.text === text) {
-                return i;
-            }
-        }
-        return -1;
     }
 
     private markDayAsRead(day: string): void {
-        if (this.auth.userEmail === null) {
+        if (!this.userDoc) {
             return;
         }
-        this.userDoc!.get().subscribe((val) => {
-            if (val.exists) {
-                const data = val.data();
-                if (data && data.days.indexOf(day) === -1) {
-                    data.days.push(day);
-                    this.userDoc!.update(data).then().catch(err => console.error('Error marking day as read:', err));
-                }
-            } else {
-                const data = { ...this.INITIAL_DATA, days: [day] };
-                this.userDoc!.set(data).then().catch(err => console.error('Error creating document:', err));
-            }
-        });
+        // arrayUnion is idempotent, so no need to read-and-check before writing.
+        this.userDoc.set({days: arrayUnion(day)} as unknown as Item, {merge: true})
+            .catch(err => console.error('Error marking day as read:', err));
     }
 }

--- a/src/app/today/text-select-event.directive.ts
+++ b/src/app/today/text-select-event.directive.ts
@@ -19,6 +19,10 @@ interface SelectionRectangle {
 
 @Directive({
     selector: '[textSelect]',
+    // Aliased output: bound as `(textSelect)` in templates but exposed as `textSelectEvent`
+    // on the class. Both the metadata form and `@Output('textSelect')` are flagged by
+    // angular-eslint rules, so the alias is declared here with the rule disabled.
+    // eslint-disable-next-line @angular-eslint/no-outputs-metadata-property
     outputs: ['textSelectEvent: textSelect'],
     standalone: false
 })

--- a/src/app/today/today.page.ts
+++ b/src/app/today/today.page.ts
@@ -26,6 +26,7 @@ export class TodayPage implements OnInit, OnDestroy {
   title!: string;
   header!: string;
   html!: string;
+  private rawHtml = "";
   isFavorite: boolean = false;
   progress = 0;
   notes: string[] = [];
@@ -151,16 +152,18 @@ export class TodayPage implements OnInit, OnDestroy {
     this.material.ready().then((json) => {
       const dayData = json[month].find((item: any) => item.day === split[1]);
       this.header = dayData["title"];
-      this.html = dayData["content"];
+      this.rawHtml = dayData["content"];
+      this.html = this.rawHtml;
       this.content.scrollToTop();
       this.dbSub = this.db.userDocValue().subscribe((val) => {
         if (!val) return;
         this.isFavorite =
           val.favorites !== undefined && val.favorites.indexOf(this.day) !== -1;
-        this.notes = val.notes
+        this.notes = (val.notes ?? [])
           .filter((note) => note.day === this.day)
           .map((note) => note.text);
-        this.html = this.highlightedHtml(this.html, this.notes);
+        // Always highlight from the pristine content so spans never nest on re-emission.
+        this.html = this.highlightedHtml(this.rawHtml, this.notes);
       });
     });
   }


### PR DESCRIPTION
ReadingDbService now uses atomic arrayUnion/arrayRemove field ops with set(..., {merge:true}) instead of read-modify-write of the whole user doc, fixing concurrent-write clobbering. FieldValue is resolved at call time and firebase/compat/firestore is side-effect imported so the namespace exists.

TodayPage derives `html` from a pristine `rawHtml` each render so highlight spans no longer nest on valueChanges re-emission. Array reads guarded with `?? []` since merged docs may hold only some fields.

Added EVENT_USER_LOGOUT (published by AuthService) so ReadingDbService resets userDoc on sign-out.

Restored linting: replaced the removed tslint builder with @angular-eslint/builder:lint + an ESLint 10 flat config (eslint.config.mjs). prefer-standalone/prefer-inject disabled to match the NgModule + constructor-DI architecture; no-explicit-any set to warn. Fixed the genuine findings (unused import, empty lifecycle method).